### PR TITLE
fix(identity): 开伪装补齐出站身份并按客户端派生 DeviceId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ CLAUDE.md
 
 # 本地文档和归档
 /docs/
+
+# OpenCode 本会话黑板，不入库
+PLAN-*.md

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,3 @@ CLAUDE.md
 
 # 本地文档和归档
 /docs/
-
-# OpenCode 本会话黑板，不入库
-PLAN-*.md

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -2,7 +2,9 @@ package identity
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -53,10 +55,11 @@ type persisted struct {
 }
 
 type Manager struct {
-	store       *storage.Store
-	mu          sync.Mutex
-	profiles    map[string]deviceState
-	initialized bool
+	store        *storage.Store
+	mu           sync.Mutex
+	profiles     map[string]deviceState
+	initialized  bool
+	tokenAliases map[string]string
 }
 
 var Profiles = map[string]Profile{
@@ -67,7 +70,7 @@ var Profiles = map[string]Profile{
 		ClientVersion:  "2.0.4.6",
 		DeviceName:     "Android",
 		DeviceIDFormat: "uuid",
-		UserAgent:      "Yamby/2.0.4.6(Android",
+		UserAgent:      "Yamby/2.0.4.6(Android)",
 	},
 	"hills_android": {
 		Key:            "hills_android",
@@ -91,13 +94,15 @@ var Profiles = map[string]Profile{
 var ProfileOrder = []string{DefaultProfile, "hills_android", "hills_windows"}
 
 var (
-	embyAuthorizationRE      = regexp.MustCompile(`(?i)^(?:MediaBrowser|Emby)(?:\s|$)`)
-	embyAuthorizationTokenRE = regexp.MustCompile(`(?i)^(?:MediaBrowser|Emby)(?:\s|$).*?\bToken\s*=\s*("[^"]*"|[^,\s]+)`)
-	authorizationHeaderKeys  = []string{"X-Emby-Authorization", "X-MediaBrowser-Authorization", "Authorization", "X-Authorization"}
+	embyAuthorizationRE         = regexp.MustCompile(`(?i)^(?:MediaBrowser|Emby)(?:\s|$)`)
+	embyAuthorizationTokenRE    = regexp.MustCompile(`(?i)^(?:MediaBrowser|Emby)(?:\s|$).*?\bToken\s*=\s*("[^"]*"|[^,\s]+)`)
+	embyAuthorizationDeviceIDRE = regexp.MustCompile(`(?i)\bDeviceId\s*=\s*("[^"]*"|[^,\s]+)`)
+	embyAuthorizationClientRE   = regexp.MustCompile(`(?i)\bClient\s*=\s*("[^"]*"|[^,\s]+)`)
+	authorizationHeaderKeys     = []string{"X-Emby-Authorization", "X-MediaBrowser-Authorization", "Authorization", "X-Authorization"}
 )
 
 func NewManager(store *storage.Store) *Manager {
-	return &Manager{store: store, profiles: map[string]deviceState{}}
+	return &Manager{store: store, profiles: map[string]deviceState{}, tokenAliases: map[string]string{}}
 }
 
 func (m *Manager) Init(ctx context.Context) error {
@@ -128,6 +133,10 @@ func (m *Manager) snapshotLocked(profile string) Snapshot {
 	if len(shortID) > 8 {
 		shortID = shortID[:8]
 	}
+	ua := selected.UserAgent
+	if ua == "Yamby/2.0.4.6(Android" {
+		ua = "Yamby/2.0.4.6(Android)"
+	}
 	return Snapshot{
 		Profile:       selected.Key,
 		Label:         selected.Label,
@@ -136,27 +145,157 @@ func (m *Manager) snapshotLocked(profile string) Snapshot {
 		DeviceName:    state.DeviceName,
 		DeviceID:      state.DeviceID,
 		ShortID:       shortID,
-		UserAgent:     selected.UserAgent,
+		UserAgent:     ua,
 	}
 }
 
-func (m *Manager) ApplyToHeaders(headers http.Header, profile string) {
-	snap := m.Snapshot(profile)
-	applyProfileIdentityToHeaders(headers, snap)
+func (m *Manager) RememberTokenDeviceID(token, deviceID string) {
+	token = strings.TrimSpace(token)
+	deviceID = strings.TrimSpace(deviceID)
+	if token == "" || deviceID == "" {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.tokenAliases == nil {
+		m.tokenAliases = make(map[string]string)
+	}
+	if len(m.tokenAliases) > 10000 {
+		m.tokenAliases = make(map[string]string)
+	}
+	m.tokenAliases[token] = deviceID
 }
 
-func applyProfileIdentityToHeaders(headers http.Header, snap Snapshot) {
+func (m *Manager) LookupTokenDeviceID(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.tokenAliases == nil {
+		return ""
+	}
+	return m.tokenAliases[token]
+}
+
+func DeriveDeviceID(secret, profileKey, inboundDeviceID string, p Profile) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(profileKey + "\x00" + inboundDeviceID))
+	sum := mac.Sum(nil)
+
+	switch strings.ToLower(strings.TrimSpace(p.DeviceIDFormat)) {
+	case "uuid":
+		buf := make([]byte, 16)
+		copy(buf, sum[:16])
+		buf[6] = (buf[6] & 0x0f) | 0x40 // Version 4
+		buf[8] = (buf[8] & 0x3f) | 0x80 // RFC 4122 variant
+		hexed := hex.EncodeToString(buf)
+		return hexed[:8] + "-" + hexed[8:12] + "-" + hexed[12:16] + "-" + hexed[16:20] + "-" + hexed[20:]
+	default:
+		length := p.DeviceIDLength
+		if length <= 0 {
+			length = 32
+		}
+		hexed := hex.EncodeToString(sum)
+		if len(hexed) > length {
+			return hexed[:length]
+		}
+		return hexed
+	}
+}
+
+func inboundDeviceIDFromAuth(auth string) string {
+	matches := embyAuthorizationDeviceIDRE.FindStringSubmatch(strings.TrimSpace(auth))
+	if len(matches) < 2 {
+		return ""
+	}
+	return unquoteAuthFieldValue(matches[1])
+}
+
+func InboundDeviceIDFromHeaders(headers http.Header) string {
+	if headers == nil {
+		return ""
+	}
+	if id := firstSanitizedToken(
+		firstHeaderValue(headers, "X-Emby-Device-Id"),
+		firstHeaderValue(headers, "X-MediaBrowser-DeviceId"),
+		firstHeaderValueByNormalizedKey(headers, "xembydeviceid"),
+		firstHeaderValueByNormalizedKey(headers, "xmediabrowserdeviceid"),
+	); id != "" {
+		return id
+	}
+	for _, key := range authorizationHeaderKeys {
+		if id := inboundDeviceIDFromAuth(firstHeaderValue(headers, key)); id != "" {
+			return id
+		}
+	}
+	for key, values := range headers {
+		if !isAuthorizationKey(normalizeHeaderKey(key)) {
+			continue
+		}
+		for _, value := range values {
+			if id := inboundDeviceIDFromAuth(value); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+func (m *Manager) ResolveOutboundDeviceID(secret string, snap Snapshot, inboundDeviceID, token string) string {
+	p := GetProfile(snap.Profile)
+	inboundDeviceID = strings.TrimSpace(inboundDeviceID)
+	token = strings.TrimSpace(token)
+
+	if inboundDeviceID != "" {
+		outboundID := DeriveDeviceID(secret, snap.Profile, inboundDeviceID, p)
+		if token != "" {
+			m.RememberTokenDeviceID(token, outboundID)
+		}
+		return outboundID
+	}
+
+	if token != "" {
+		if cached := m.LookupTokenDeviceID(token); cached != "" {
+			return cached
+		}
+	}
+
+	return snap.DeviceID
+}
+
+func (m *Manager) ApplyToHeaders(headers http.Header, profile string, secret ...string) {
+	snap := m.Snapshot(profile)
+	sec := ""
+	if len(secret) > 0 {
+		sec = secret[0]
+	}
+	m.applyProfileIdentityToHeaders(headers, snap, sec)
+}
+
+func (m *Manager) applyProfileIdentityToHeaders(headers http.Header, snap Snapshot, secret string) {
 	if headers == nil {
 		return
 	}
 	token := identityTokenFromHeaders(headers)
-	auth := firstEmbyAuthorizationHeader(headers)
+	inboundDeviceID := InboundDeviceIDFromHeaders(headers)
+	outboundDeviceID := m.ResolveOutboundDeviceID(secret, snap, inboundDeviceID, token)
+
 	stripImpersonationHeaders(headers)
-	switch {
-	case usesHillsAuthFormat(snap):
-		headers.Set("X-Emby-Authorization", buildHillsAuthorization(snap))
-	case auth != "":
-		headers.Set("X-Emby-Authorization", buildYambyAuthorization(auth, snap))
+
+	currentSnap := snap
+	currentSnap.DeviceID = outboundDeviceID
+
+	headers.Set("X-Emby-Client", currentSnap.ClientName)
+	headers.Set("X-Emby-Client-Version", currentSnap.ClientVersion)
+	headers.Set("X-Emby-Device-Name", currentSnap.DeviceName)
+	headers.Set("X-Emby-Device-Id", currentSnap.DeviceID)
+
+	if usesHillsAuthFormat(currentSnap) {
+		headers.Set("X-Emby-Authorization", buildHillsAuthorization(currentSnap))
+	} else {
+		headers.Set("X-Emby-Authorization", buildYambyAuthorization("", currentSnap))
 	}
 	if token != "" {
 		headers.Set("X-Emby-Token", token)
@@ -200,50 +339,90 @@ func deleteHeaderKey(headers http.Header, key string) {
 	headers.Del(key)
 }
 
-func (m *Manager) ApplyToURL(u *url.URL, headers http.Header, profile string) {
+func (m *Manager) ApplyToURL(u *url.URL, headers http.Header, profile string, secret ...string) {
 	if u == nil {
 		return
 	}
 	snap := m.Snapshot(profile)
+	sec := ""
+	if len(secret) > 0 {
+		sec = secret[0]
+	}
 	if usesYambyAuthFormat(snap) {
+		inboundDeviceID := firstSanitizedToken(
+			firstQueryValueByNormalizedKey(u, "xembydeviceid"),
+			firstQueryValueByNormalizedKey(u, "xmediabrowserdeviceid"),
+			firstQueryValueByNormalizedKey(u, "deviceid"),
+		)
+		token := firstSanitizedToken(
+			firstQueryValueByNormalizedKey(u, "xembytoken"),
+			firstQueryValueByNormalizedKey(u, "xmediabrowsertoken"),
+			firstQueryValueByNormalizedKey(u, "apikey"),
+			firstQueryValueByNormalizedKey(u, "token"),
+			authTokenFromURL(u),
+			authTokenFromHeaders(headers),
+		)
+		if inboundDeviceID != "" && token != "" {
+			outboundID := m.ResolveOutboundDeviceID(sec, snap, inboundDeviceID, token)
+			m.RememberTokenDeviceID(token, outboundID)
+		}
 		applyYambyQueryAuthToHeaders(u, headers)
 		setTokenHeaderIfMissing(headers, authTokenFromHeaders(headers))
 		return
 	}
 	if usesHillsAuthFormat(snap) {
-		applyHillsQueryIdentityToURL(u, headers, snap)
+		m.applyHillsQueryIdentityToURL(u, headers, snap, sec)
 		return
 	}
 	setTokenHeaderIfMissing(headers, authTokenFromURL(u))
 	applyProfileIdentityToURL(u, snap)
 }
 
-func (m *Manager) ApplyToResourceURL(u *url.URL, headers http.Header, profile string) {
+func (m *Manager) ApplyToResourceURL(u *url.URL, headers http.Header, profile string, secret ...string) {
 	if u == nil {
 		return
 	}
 	snap := m.Snapshot(profile)
+	sec := ""
+	if len(secret) > 0 {
+		sec = secret[0]
+	}
 	if usesYambyAuthFormat(snap) {
 		applyYambyQueryAuthToHeaders(u, headers)
 		setTokenHeaderIfMissing(headers, authTokenFromHeaders(headers))
 		return
 	}
 	if usesHillsAuthFormat(snap) {
-		applyHillsResourceIdentityToURL(u, headers, snap)
+		m.applyHillsResourceIdentityToURL(u, headers, snap, sec)
 		return
 	}
 	setTokenHeaderIfMissing(headers, authTokenFromURL(u))
 	applyProfileIdentityToURL(u, snap)
 }
 
-func (m *Manager) ApplyToDirectURL(u *url.URL, headers http.Header, profile string) {
+func (m *Manager) ApplyToDirectURL(u *url.URL, headers http.Header, profile string, secret ...string) {
 	snap := m.Snapshot(profile)
 	setTokenHeaderIfMissing(headers, firstSanitizedToken(
 		firstQueryValueByNormalizedKey(u, "xembytoken"),
 		firstQueryValueByNormalizedKey(u, "xmediabrowsertoken"),
+		firstQueryValueByNormalizedKey(u, "apikey"),
+		firstQueryValueByNormalizedKey(u, "token"),
 		authTokenFromURL(u),
 	))
-	applyProfileIdentityToHeaders(headers, snap)
+	if headers != nil && InboundDeviceIDFromHeaders(headers) == "" {
+		if qDevID := firstSanitizedToken(
+			firstQueryValueByNormalizedKey(u, "xembydeviceid"),
+			firstQueryValueByNormalizedKey(u, "xmediabrowserdeviceid"),
+			firstQueryValueByNormalizedKey(u, "deviceid"),
+		); qDevID != "" {
+			headers.Set("X-Emby-Device-Id", qDevID)
+		}
+	}
+	sec := ""
+	if len(secret) > 0 {
+		sec = secret[0]
+	}
+	m.applyProfileIdentityToHeaders(headers, snap, sec)
 }
 
 func setTokenHeaderIfMissing(headers http.Header, token string) {
@@ -253,15 +432,28 @@ func setTokenHeaderIfMissing(headers http.Header, token string) {
 	headers.Set("X-Emby-Token", sanitizeHeaderValue(token))
 }
 
-func applyHillsQueryIdentityToURL(u *url.URL, headers http.Header, snap Snapshot) {
+func (m *Manager) applyHillsQueryIdentityToURL(u *url.URL, headers http.Header, snap Snapshot, secret string) {
 	q := u.Query()
 	token := hillsTokenForURL(u, headers)
+	inboundDeviceID := InboundDeviceIDFromHeaders(headers)
+	if inboundDeviceID == "" {
+		inboundDeviceID = firstSanitizedToken(
+			firstQueryValueByNormalizedKey(u, "xembydeviceid"),
+			firstQueryValueByNormalizedKey(u, "xmediabrowserdeviceid"),
+			firstQueryValueByNormalizedKey(u, "deviceid"),
+		)
+	}
+	currentSnap := snap
+	if inboundDeviceID != "" || token != "" {
+		outboundDeviceID := m.ResolveOutboundDeviceID(secret, snap, inboundDeviceID, token)
+		currentSnap.DeviceID = outboundDeviceID
+	}
 	removeHillsQueryIdentity(q)
-	q.Set("X-Emby-Authorization", buildHillsAuthorization(snap))
-	q.Set("X-Emby-Client", snap.ClientName)
-	q.Set("X-Emby-Device-Name", snap.DeviceName)
-	q.Set("X-Emby-Device-Id", snap.DeviceID)
-	q.Set("X-Emby-Client-Version", snap.ClientVersion)
+	q.Set("X-Emby-Authorization", buildHillsAuthorization(currentSnap))
+	q.Set("X-Emby-Client", currentSnap.ClientName)
+	q.Set("X-Emby-Device-Name", currentSnap.DeviceName)
+	q.Set("X-Emby-Device-Id", currentSnap.DeviceID)
+	q.Set("X-Emby-Client-Version", currentSnap.ClientVersion)
 	q.Set("X-Emby-Language", hillsLanguageForURL(u))
 	if token != "" {
 		q.Set("X-Emby-Token", token)
@@ -292,14 +484,14 @@ func isUsersRootPath(u *url.URL) bool {
 	return false
 }
 
-func applyHillsResourceIdentityToURL(u *url.URL, headers http.Header, snap Snapshot) {
+func (m *Manager) applyHillsResourceIdentityToURL(u *url.URL, headers http.Header, snap Snapshot, secret string) {
 	token := hillsTokenForURL(u, headers)
 	q := u.Query()
 	if removeHillsQueryIdentity(q) {
 		u.RawQuery = q.Encode()
 	}
 	setTokenHeaderIfMissing(headers, token)
-	applyProfileIdentityToHeaders(headers, snap)
+	m.applyProfileIdentityToHeaders(headers, snap, secret)
 }
 
 func removeHillsQueryIdentity(q url.Values) bool {
@@ -478,7 +670,7 @@ func isYambyQueryIdentityKey(normalizedKey string) bool {
 		return true
 	}
 	switch normalizedKey {
-	case "deviceid", "devicename":
+	case "deviceid", "devicename", "client", "version":
 		return true
 	default:
 		return false

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -157,7 +157,8 @@ func TestApplyToHeadersMovesAuthorizationToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := NewManager(nil)
 			snap := manager.Snapshot(DefaultProfile)
-			wantAuth := "Emby Client=" + snap.ClientName + ",Device=" + snap.DeviceName + ",DeviceId=" + snap.DeviceID + ",Version=" + snap.ClientVersion
+			wantDeviceID := DeriveDeviceID("", DefaultProfile, "source-device-id", GetProfile(DefaultProfile))
+			wantAuth := "Emby Client=" + snap.ClientName + ",Device=" + snap.DeviceName + ",DeviceId=" + wantDeviceID + ",Version=" + snap.ClientVersion
 
 			manager.ApplyToHeaders(tt.headers, DefaultProfile)
 
@@ -206,13 +207,25 @@ func TestApplyToHeadersRewritesEmbyAuthorization(t *testing.T) {
 
 	manager.ApplyToHeaders(headers, "yamby")
 
+	wantDeviceID := DeriveDeviceID("", "yamby", "original-device", GetProfile("yamby"))
+	if got := headers.Get("X-Emby-Client"); got != "Yamby" {
+		t.Fatalf("X-Emby-Client = %q, want Yamby", got)
+	}
+	if got := headers.Get("X-Emby-Client-Version"); got != "2.0.4.6" {
+		t.Fatalf("X-Emby-Client-Version = %q, want 2.0.4.6", got)
+	}
+	if got := headers.Get("X-Emby-Device-Name"); got != "Android" {
+		t.Fatalf("X-Emby-Device-Name = %q, want Android", got)
+	}
+	if got := headers.Get("X-Emby-Device-Id"); got != wantDeviceID {
+		t.Fatalf("X-Emby-Device-Id = %q, want derived %q", got, wantDeviceID)
+	}
 	value := headers.Get("X-Emby-Authorization")
-	if !strings.Contains(value, `Client=Yamby`) || !strings.Contains(value, `Device=Android`) {
+	if !strings.Contains(value, `Client=Yamby`) || !strings.Contains(value, `Device=Android`) || !strings.Contains(value, `DeviceId=`+wantDeviceID) {
 		t.Fatalf("X-Emby-Authorization was not rewritten to yamby identity: %s", value)
 	}
 	for _, key := range []string{
 		"Authorization", "X-Authorization", "X-Application", "X-MediaBrowser-Authorization", "X-MediaBrowser-Token",
-		"X-Emby-Client", "X-Emby-Client-Version", "X-Emby-Device-Id", "X-Emby-Device-Name",
 		"X-MediaBrowser-Client", "X-MediaBrowser-Client-Version", "X-MediaBrowser-Device-Id", "X-MediaBrowser-Device-Name",
 	} {
 		if got := headers.Get(key); got != "" {
@@ -254,6 +267,11 @@ func TestApplyToHeadersPromotesMediaBrowserToken(t *testing.T) {
 
 func TestApplyToHeadersNormalizesUnderscoreHeaderAliases(t *testing.T) {
 	manager := NewManager(nil)
+	yambySnap := manager.Snapshot("yamby")
+	yambySnap.DeviceID = DeriveDeviceID("", "yamby", "source-device-id", Profiles["yamby"])
+	hillsSnap := manager.Snapshot("hills_windows")
+	hillsSnap.DeviceID = DeriveDeviceID("", "hills_windows", "source-device-id", Profiles["hills_windows"])
+
 	tests := []struct {
 		name    string
 		profile string
@@ -262,12 +280,12 @@ func TestApplyToHeadersNormalizesUnderscoreHeaderAliases(t *testing.T) {
 		{
 			name:    "yamby",
 			profile: "yamby",
-			want:    buildYambyAuthorization(testSourceEmbyTokenAuth, manager.Snapshot("yamby")),
+			want:    buildYambyAuthorization(testSourceEmbyTokenAuth, yambySnap),
 		},
 		{
 			name:    "hills",
 			profile: "hills_windows",
-			want:    buildHillsAuthorization(manager.Snapshot("hills_windows")),
+			want:    buildHillsAuthorization(hillsSnap),
 		},
 	}
 
@@ -295,13 +313,29 @@ func TestApplyToHeadersNormalizesUnderscoreHeaderAliases(t *testing.T) {
 	}
 }
 
-func TestApplyToHeadersDoesNotAddMissingEmbyHeaders(t *testing.T) {
+func TestApplyToHeadersAddsMissingProfileHeaders(t *testing.T) {
 	manager := NewManager(nil)
 	headers := http.Header{}
 
 	manager.ApplyToHeaders(headers, "yamby")
 
-	for _, key := range []string{"Authorization", "X-Application", "X-Emby-Authorization", "X-Emby-Client", "X-Emby-Client-Version", "X-Emby-Device-Name", "X-Emby-Device-Id"} {
+	snap := manager.Snapshot("yamby")
+	if got := headers.Get("X-Emby-Client"); got != "Yamby" {
+		t.Fatalf("X-Emby-Client = %q, want Yamby", got)
+	}
+	if got := headers.Get("X-Emby-Client-Version"); got != "2.0.4.6" {
+		t.Fatalf("X-Emby-Client-Version = %q, want 2.0.4.6", got)
+	}
+	if got := headers.Get("X-Emby-Device-Name"); got != "Android" {
+		t.Fatalf("X-Emby-Device-Name = %q, want Android", got)
+	}
+	if got := headers.Get("X-Emby-Device-Id"); got != snap.DeviceID {
+		t.Fatalf("X-Emby-Device-Id = %q, want fallback device ID %q", got, snap.DeviceID)
+	}
+	if got := headers.Get("X-Emby-Authorization"); !strings.Contains(got, "Client=Yamby") {
+		t.Fatalf("X-Emby-Authorization = %q, want Yamby authorization", got)
+	}
+	for _, key := range []string{"Authorization", "X-Application", "X-MediaBrowser-Authorization"} {
 		if got := headers.Get(key); got != "" {
 			t.Fatalf("%s = %q, want empty", key, got)
 		}
@@ -323,7 +357,22 @@ func TestApplyToHeadersNormalizesHillsIdentityHeaders(t *testing.T) {
 
 	manager.ApplyToHeaders(headers, "hills_windows")
 
+	wantDeviceID := DeriveDeviceID("", "hills_windows", "original-device", Profiles["hills_windows"])
 	snap := manager.Snapshot("hills_windows")
+	snap.DeviceID = wantDeviceID
+
+	if got := headers.Get("X-Emby-Client"); got != "Hills Windows" {
+		t.Fatalf("X-Emby-Client = %q, want Hills Windows", got)
+	}
+	if got := headers.Get("X-Emby-Client-Version"); got != "1.3.1" {
+		t.Fatalf("X-Emby-Client-Version = %q, want 1.3.1", got)
+	}
+	if got := headers.Get("X-Emby-Device-Name"); got != snap.DeviceName {
+		t.Fatalf("X-Emby-Device-Name = %q, want %q", got, snap.DeviceName)
+	}
+	if got := headers.Get("X-Emby-Device-Id"); got != wantDeviceID {
+		t.Fatalf("X-Emby-Device-Id = %q, want %q", got, wantDeviceID)
+	}
 	if got := headers.Get("X-Emby-Authorization"); got != buildHillsAuthorization(snap) {
 		t.Fatalf("X-Emby-Authorization = %q, want Hills auth", got)
 	}
@@ -331,8 +380,7 @@ func TestApplyToHeadersNormalizesHillsIdentityHeaders(t *testing.T) {
 		t.Fatalf("X-Emby-Token = %q, want source-token", got)
 	}
 	for _, key := range []string{
-		"Authorization", "X-Authorization", "X-Application",
-		"X-Emby-Client", "X-Emby-Client-Version", "X-Emby-Device-Name", "X-Emby-Device-Id", "X-Emby-Language",
+		"Authorization", "X-Authorization", "X-Application", "X-Emby-Language",
 		"X-MediaBrowser-Authorization", "X-MediaBrowser-Client", "X-MediaBrowser-Client-Version", "X-MediaBrowser-Device-Name", "X-MediaBrowser-Device-Id", "X-MediaBrowser-Token",
 	} {
 		if got := headers.Get(key); got != "" {
@@ -579,9 +627,10 @@ func TestApplyToURLKeepsHillsQueryIdentityBehavior(t *testing.T) {
 		}
 	}
 	query := u.Query()
+	wantDeviceID := DeriveDeviceID("", "hills_windows", "synthetic-source-device-id", Profiles["hills_windows"])
 	for key, want := range map[string]string{
 		"X-Emby-Device-Name": hillsWindows.DeviceName,
-		"X-Emby-Device-Id":   hillsWindows.DeviceID,
+		"X-Emby-Device-Id":   wantDeviceID,
 		"X-Emby-Language":    "en-us",
 		"X-Emby-Token":       "source-token",
 	} {
@@ -624,6 +673,8 @@ func TestApplyToURLNormalizesHillsQueryIdentity(t *testing.T) {
 	manager.ApplyToURL(u, headers, "hills_android")
 
 	snap := manager.Snapshot("hills_android")
+	wantDeviceID := DeriveDeviceID("", "hills_android", "source-device", Profiles["hills_android"])
+	snap.DeviceID = wantDeviceID
 	query := u.Query()
 	for key, want := range map[string]string{
 		"X-Emby-Authorization":  buildHillsAuthorization(snap),
@@ -834,5 +885,65 @@ func TestProfileDeviceIdentityDefaults(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDeriveDeviceIDFormats(t *testing.T) {
+	secret := "test-secret"
+	inboundID := "client-inbound-device-id-12345"
+
+	// 1. yamby UUIDv4
+	yambyID := DeriveDeviceID(secret, "yamby", inboundID, Profiles["yamby"])
+	if !isUUID(yambyID) {
+		t.Fatalf("yamby derived ID %q is not a valid UUID", yambyID)
+	}
+	// UUIDv4 校验: version 4, variant 1 (8, 9, a, b)
+	if yambyID[14] != '4' {
+		t.Fatalf("yamby derived ID %q version byte is %c, want 4", yambyID, yambyID[14])
+	}
+	varChar := yambyID[19]
+	if varChar != '8' && varChar != '9' && varChar != 'a' && varChar != 'b' {
+		t.Fatalf("yamby derived ID %q variant char is %c, want 8/9/a/b", yambyID, varChar)
+	}
+
+	// 2. hills_android 16 hex
+	hillsAndroidID := DeriveDeviceID(secret, "hills_android", inboundID, Profiles["hills_android"])
+	if !isHexLength(hillsAndroidID, 16) {
+		t.Fatalf("hills_android derived ID %q is not 16 hex", hillsAndroidID)
+	}
+
+	// 3. hills_windows 32 hex
+	hillsWindowsID := DeriveDeviceID(secret, "hills_windows", inboundID, Profiles["hills_windows"])
+	if !isHexLength(hillsWindowsID, 32) {
+		t.Fatalf("hills_windows derived ID %q is not 32 hex", hillsWindowsID)
+	}
+
+	// 4. 纯函数确定性
+	yambyID2 := DeriveDeviceID(secret, "yamby", inboundID, Profiles["yamby"])
+	if yambyID != yambyID2 {
+		t.Fatalf("same inputs must yield identical derived ID: %q != %q", yambyID, yambyID2)
+	}
+
+	// 5. 不同入站 DeviceId
+	yambyOther := DeriveDeviceID(secret, "yamby", "different-device", Profiles["yamby"])
+	if yambyID == yambyOther {
+		t.Fatalf("different inbound IDs must yield different derived IDs")
+	}
+
+	// 6. 出站不是入站原文
+	if yambyID == inboundID || hillsAndroidID == inboundID || hillsWindowsID == inboundID {
+		t.Fatalf("outbound ID must not equal inbound ID raw value")
+	}
+}
+
+func TestTokenAliasMapping(t *testing.T) {
+	manager := NewManager(nil)
+	if got := manager.LookupTokenDeviceID("non-existent"); got != "" {
+		t.Fatalf("lookup non-existent token = %q, want empty", got)
+	}
+
+	manager.RememberTokenDeviceID("token-123", "derived-device-id-123")
+	if got := manager.LookupTokenDeviceID("token-123"); got != "derived-device-id-123" {
+		t.Fatalf("lookup token-123 = %q, want derived-device-id-123", got)
 	}
 }

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1046,6 +1046,9 @@ func (h *Handler) doFetch(ctx context.Context, client *http.Client, target *url.
 		return nil, err
 	}
 	req.Header = cloneHeader(headers)
+	if _, ok := req.Header["User-Agent"]; !ok {
+		req.Header["User-Agent"] = nil
+	}
 	req.Host = target.Host
 	res, err := client.Do(req)
 	if err != nil {

--- a/internal/proxy/headers.go
+++ b/internal/proxy/headers.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -134,13 +135,86 @@ func deleteHeaders(h http.Header, keys ...string) {
 	}
 }
 
-func setProxyUA(ids *identity.Manager, h http.Header, node storage.Node) {
-	ua := strings.TrimSpace(h.Get("User-Agent"))
-	if node.Impersonate {
-		ua = ids.Snapshot(node.ImpersonateProfile).UserAgent
+var embyAuthorizationClientRE = regexp.MustCompile(`(?i)\bClient\s*=\s*("[^"]*"|[^,\s]+)`)
+
+func extractClientFromAuth(auth string) string {
+	matches := embyAuthorizationClientRE.FindStringSubmatch(strings.TrimSpace(auth))
+	if len(matches) < 2 {
+		return ""
 	}
+	val := strings.TrimSpace(matches[1])
+	if len(val) >= 2 && val[0] == '"' && val[len(val)-1] == '"' {
+		val = val[1 : len(val)-1]
+		val = strings.ReplaceAll(val, `\"`, `"`)
+		val = strings.ReplaceAll(val, `\\`, `\`)
+	}
+	return strings.TrimSpace(val)
+}
+
+func hasClientHeader(h http.Header) bool {
+	if h == nil {
+		return false
+	}
+	for key, values := range h {
+		nk := strings.NewReplacer("-", "", "_", "").Replace(strings.ToLower(key))
+		if nk == "xembyclient" || nk == "xmediabrowserclient" {
+			for _, v := range values {
+				if strings.TrimSpace(v) != "" {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func fillMissingClientFromAuth(h http.Header) {
+	if hasClientHeader(h) {
+		return
+	}
+	for _, key := range []string{"X-Emby-Authorization", "X-MediaBrowser-Authorization", "Authorization", "X-Authorization"} {
+		for _, authVal := range h.Values(key) {
+			if client := extractClientFromAuth(authVal); client != "" {
+				h.Set("X-Emby-Client", client)
+				return
+			}
+		}
+	}
+}
+
+func fillMissingClientFromQuery(u *url.URL, h http.Header) {
+	if u == nil || hasClientHeader(h) {
+		return
+	}
+	fillMissingClientFromAuth(h)
+	if hasClientHeader(h) {
+		return
+	}
+	for key, values := range u.Query() {
+		nk := strings.NewReplacer("-", "", "_", "").Replace(strings.ToLower(key))
+		if nk == "client" || nk == "xembyclient" || nk == "xmediabrowserclient" {
+			for _, v := range values {
+				if strings.TrimSpace(v) != "" {
+					h.Set("X-Emby-Client", strings.TrimSpace(v))
+					return
+				}
+			}
+		}
+	}
+}
+
+func setProxyUA(ids *identity.Manager, h http.Header, node storage.Node) {
+	if node.Impersonate {
+		ua := ids.Snapshot(node.ImpersonateProfile).UserAgent
+		if ua == "Yamby/2.0.4.6(Android" {
+			ua = "Yamby/2.0.4.6(Android)"
+		}
+		h.Set("User-Agent", ua)
+		return
+	}
+	ua := strings.TrimSpace(h.Get("User-Agent"))
 	if ua == "" {
-		h.Del("User-Agent")
+		h["User-Agent"] = nil
 		return
 	}
 	h.Set("User-Agent", ua)
@@ -148,25 +222,39 @@ func setProxyUA(ids *identity.Manager, h http.Header, node storage.Node) {
 
 func applyIdentity(ids *identity.Manager, h http.Header, node storage.Node) {
 	if node.Impersonate {
-		ids.ApplyToHeaders(h, node.ImpersonateProfile)
+		ids.ApplyToHeaders(h, node.ImpersonateProfile, node.Secret)
+		return
 	}
+	fillMissingClientFromAuth(h)
 }
 
 func applyIdentityToURL(ids *identity.Manager, u *url.URL, headers http.Header, node storage.Node) {
 	if node.Impersonate {
-		ids.ApplyToURL(u, headers, node.ImpersonateProfile)
+		ids.ApplyToURL(u, headers, node.ImpersonateProfile, node.Secret)
+		return
+	}
+	if u != nil && headers != nil {
+		fillMissingClientFromQuery(u, headers)
 	}
 }
 
 func applyIdentityToResourceURL(ids *identity.Manager, u *url.URL, headers http.Header, node storage.Node) {
 	if node.Impersonate {
-		ids.ApplyToResourceURL(u, headers, node.ImpersonateProfile)
+		ids.ApplyToResourceURL(u, headers, node.ImpersonateProfile, node.Secret)
+		return
+	}
+	if u != nil && headers != nil {
+		fillMissingClientFromQuery(u, headers)
 	}
 }
 
 func applyIdentityToDirectURL(ids *identity.Manager, u *url.URL, headers http.Header, node storage.Node) {
 	if node.Impersonate {
-		ids.ApplyToDirectURL(u, headers, node.ImpersonateProfile)
+		ids.ApplyToDirectURL(u, headers, node.ImpersonateProfile, node.Secret)
+		return
+	}
+	if u != nil && headers != nil {
+		fillMissingClientFromQuery(u, headers)
 	}
 }
 
@@ -180,6 +268,9 @@ func buildCleanProxyHeaders(ids *identity.Manager, raw http.Header, targetURL *u
 	h.Set("Host", targetURL.Host)
 	setProxyUA(ids, h, node)
 	applyIdentity(ids, h, node)
+	if !node.Impersonate && targetURL != nil {
+		fillMissingClientFromQuery(targetURL, h)
+	}
 	if rg := raw.Get("Range"); rg != "" {
 		h.Set("Range", rg)
 	}
@@ -203,6 +294,9 @@ func buildDirectOutboundHeaders(ids *identity.Manager, raw http.Header, targetUR
 	h.Set("Host", targetURL.Host)
 	setProxyUA(ids, h, node)
 	applyIdentity(ids, h, node)
+	if !node.Impersonate && targetURL != nil {
+		fillMissingClientFromQuery(targetURL, h)
+	}
 	if rg := raw.Get("Range"); rg != "" {
 		h.Set("Range", rg)
 	}

--- a/internal/proxy/headers_test.go
+++ b/internal/proxy/headers_test.go
@@ -67,13 +67,31 @@ func TestOutboundHeaderBuildersMapClientIdentityHeaders(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tt.name+" without identity headers", func(t *testing.T) {
-			assertNoIdentityHeaders(t, tt.build(http.Header{"User-Agent": {"Client/1.0"}}))
+		t.Run(tt.name+" with full impersonation identity headers", func(t *testing.T) {
+			headers := tt.build(http.Header{"User-Agent": {"Client/1.0"}})
+			if got := headers.Get("X-Emby-Client"); got != "Yamby" {
+				t.Fatalf("X-Emby-Client = %q, want Yamby", got)
+			}
+			if got := headers.Get("X-Emby-Client-Version"); got != "2.0.4.6" {
+				t.Fatalf("X-Emby-Client-Version = %q, want 2.0.4.6", got)
+			}
+			if got := headers.Get("X-Emby-Device-Name"); got != "Android" {
+				t.Fatalf("X-Emby-Device-Name = %q, want Android", got)
+			}
+			if got := headers.Get("X-Emby-Device-Id"); got == "" {
+				t.Fatalf("X-Emby-Device-Id is empty")
+			}
+			if got := headers.Get("X-Emby-Authorization"); !strings.Contains(got, "Client=Yamby") || !strings.Contains(got, "DeviceId="+headers.Get("X-Emby-Device-Id")) {
+				t.Fatalf("X-Emby-Authorization = %q, want Yamby identity", got)
+			}
+			if got := headers.Get("User-Agent"); got != "Yamby/2.0.4.6(Android)" {
+				t.Fatalf("User-Agent = %q, want Yamby UA", got)
+			}
 		})
 	}
 
 	for _, raw := range []http.Header{{}, {"User-Agent": {"Client/1.0"}}} {
-		if got := buildDirect(raw).Get("User-Agent"); got != "Yamby/2.0.4.6(Android" {
+		if got := buildDirect(raw).Get("User-Agent"); got != "Yamby/2.0.4.6(Android)" {
 			t.Fatalf("User-Agent = %q, want impersonated user agent", got)
 		}
 	}
@@ -255,11 +273,18 @@ func TestOutboundHeaderBuildersNormalizeHillsHeadersAndKeepOrdinaryHeaders(t *te
 		t.Run(tt.name, func(t *testing.T) {
 			headers := tt.build(raw)
 			snap := ids.Snapshot("hills_windows")
+			wantDeviceID := identity.DeriveDeviceID(node.Secret, "hills_windows", "source-device", identity.GetProfile("hills_windows"))
 			if got := headers.Get("User-Agent"); got != snap.UserAgent {
 				t.Fatalf("User-Agent = %q, want %q", got, snap.UserAgent)
 			}
-			if got := headers.Get("X-Emby-Authorization"); !strings.Contains(got, `Client="Hills Windows"`) || !strings.Contains(got, `DeviceId="`+snap.DeviceID+`"`) {
-				t.Fatalf("X-Emby-Authorization = %q, want Hills identity", got)
+			if got := headers.Get("X-Emby-Authorization"); !strings.Contains(got, `Client="Hills Windows"`) || !strings.Contains(got, `DeviceId="`+wantDeviceID+`"`) {
+				t.Fatalf("X-Emby-Authorization = %q, want Hills identity with derived device id", got)
+			}
+			if got := headers.Get("X-Emby-Client"); got != "Hills Windows" {
+				t.Fatalf("X-Emby-Client = %q, want Hills Windows", got)
+			}
+			if got := headers.Get("X-Emby-Device-Id"); got != wantDeviceID {
+				t.Fatalf("X-Emby-Device-Id = %q, want derived device id %q", got, wantDeviceID)
 			}
 			if got := headers.Get("X-Emby-Token"); got != "source-token" {
 				t.Fatalf("X-Emby-Token = %q, want source-token", got)
@@ -277,7 +302,7 @@ func TestOutboundHeaderBuildersNormalizeHillsHeadersAndKeepOrdinaryHeaders(t *te
 			}
 			assertHeaderKeysAbsent(t, headers,
 				"Authorization", "X-Authorization",
-				"X-Emby-Client", "X-MediaBrowser-Client",
+				"X-MediaBrowser-Client",
 			)
 		})
 	}
@@ -299,7 +324,6 @@ func TestWebSocketHandshakeAddsHillsIdentityQuery(t *testing.T) {
 	applyIdentityToURL(ids, targetURL, outboundHeaders, node)
 	headers := buildWebSocketHeaders(ids, outboundHeaders, targetURL, node)
 
-	snap := ids.Snapshot("hills_windows")
 	query := targetURL.Query()
 	if got := query.Get("X-Emby-Language"); got != "zh-cn" {
 		t.Fatalf("X-Emby-Language = %q, want zh-cn", got)
@@ -310,7 +334,8 @@ func TestWebSocketHandshakeAddsHillsIdentityQuery(t *testing.T) {
 	if got := query.Get("tag"); got != "v1" {
 		t.Fatalf("tag = %q, want v1", got)
 	}
-	if got := query.Get("X-Emby-Authorization"); !strings.Contains(got, `Client="Hills Windows"`) || !strings.Contains(got, `DeviceId="`+snap.DeviceID+`"`) {
+	wantDeviceID := identity.DeriveDeviceID(node.Secret, "hills_windows", "source-device", identity.GetProfile("hills_windows"))
+	if got := query.Get("X-Emby-Authorization"); !strings.Contains(got, `Client="Hills Windows"`) || !strings.Contains(got, `DeviceId="`+wantDeviceID+`"`) {
 		t.Fatalf("X-Emby-Authorization = %q, want Hills identity", got)
 	}
 	if query.Has("x_emby_device_id") {
@@ -351,5 +376,180 @@ func assertNoIdentityHeaders(t *testing.T, headers http.Header, except ...string
 		if got := headers.Get(key); got != "" {
 			t.Fatalf("%s = %q, want empty", key, got)
 		}
+	}
+}
+
+func TestUnimpersonatedUserAgentBehavior(t *testing.T) {
+	ids := identity.NewManager(nil)
+	node := storage.Node{Impersonate: false}
+	targetURL, _ := url.Parse("https://upstream.example/emby/Items")
+
+	// 1. 关伪装有 UA：出站保持原 UA，不是 Go-http-client，不是 Profile UA
+	rawWithUA := http.Header{"User-Agent": {"Lenna/1.0"}}
+	h1 := buildCleanProxyHeaders(ids, rawWithUA, targetURL, node, config.ProxyEnv{}, false)
+	if got := h1.Get("User-Agent"); got != "Lenna/1.0" {
+		t.Fatalf("User-Agent = %q, want Lenna/1.0", got)
+	}
+
+	// 2. 关伪装无 UA：保留 key 为 nil，避免 Go 补默认 UA
+	rawNoUA := http.Header{}
+	h2 := buildCleanProxyHeaders(ids, rawNoUA, targetURL, node, config.ProxyEnv{}, false)
+	vals, ok := h2["User-Agent"]
+	if !ok {
+		t.Fatalf("expected User-Agent key to be present to suppress Go-http-client")
+	}
+	if len(vals) != 0 {
+		t.Fatalf("expected User-Agent slice to be nil/empty, got %v", vals)
+	}
+}
+
+func TestUnimpersonatedMissingClientFallback(t *testing.T) {
+	ids := identity.NewManager(nil)
+	node := storage.Node{Impersonate: false}
+
+	// 1. 原有 X-Emby-Client 保留，不被改写
+	u1, _ := url.Parse("https://upstream.example/emby/Items?client=other")
+	h1 := http.Header{
+		"X-Emby-Client": {"OriginalClient"},
+	}
+	out1 := buildCleanProxyHeaders(ids, h1, u1, node, config.ProxyEnv{}, false)
+	if got := out1.Get("X-Emby-Client"); got != "OriginalClient" {
+		t.Fatalf("X-Emby-Client = %q, want OriginalClient", got)
+	}
+	assertNoIdentityHeaders(t, out1, "X-Emby-Client")
+
+	// 2. 无 Client，从 Authorization Client= 补缺
+	u2, _ := url.Parse("https://upstream.example/emby/Items")
+	h2 := http.Header{
+		"X-Emby-Authorization": {`Emby Client="FromAuth", Device="Dev", DeviceId="id", Version="1.0"`},
+	}
+	out2 := buildCleanProxyHeaders(ids, h2, u2, node, config.ProxyEnv{}, false)
+	if got := out2.Get("X-Emby-Client"); got != "FromAuth" {
+		t.Fatalf("X-Emby-Client = %q, want FromAuth", got)
+	}
+
+	// 3. 无 Client，从 query client 补缺
+	u3, _ := url.Parse("https://upstream.example/emby/Items?client=FromQuery")
+	h3 := http.Header{}
+	out3 := buildCleanProxyHeaders(ids, h3, u3, node, config.ProxyEnv{}, false)
+	if got := out3.Get("X-Emby-Client"); got != "FromQuery" {
+		t.Fatalf("X-Emby-Client = %q, want FromQuery", got)
+	}
+
+	// 4. 两者都无，禁止兜底
+	u4, _ := url.Parse("https://upstream.example/emby/Items")
+	h4 := http.Header{}
+	out4 := buildCleanProxyHeaders(ids, h4, u4, node, config.ProxyEnv{}, false)
+	if got := out4.Get("X-Emby-Client"); got != "" {
+		t.Fatalf("X-Emby-Client = %q, want empty (no fallback)", got)
+	}
+}
+
+func TestVidhubImpersonatedIdentityOutbound(t *testing.T) {
+	ids := identity.NewManager(nil)
+	node := storage.Node{
+		Impersonate:        true,
+		ImpersonateProfile: "yamby",
+		Secret:             "test-node-secret",
+	}
+
+	targetURL, _ := url.Parse("https://upstream.example/emby/Items?client=vidhub&version=1.0.0&tag=v1")
+	rawHeaders := http.Header{
+		"User-Agent":       {"Vidhub/1.0.0(iOS)"},
+		"X-Emby-Device-Id": {"vidhub-device-uuid-1"},
+		"X-Emby-Token":     {"vidhub-token-123"},
+	}
+
+	applyIdentityToURL(ids, targetURL, rawHeaders, node)
+
+	// query 中必须删除了 client 和 version，但保留其他 query
+	if targetURL.Query().Has("client") {
+		t.Fatalf("query still has client: %s", targetURL.RawQuery)
+	}
+	if targetURL.Query().Has("version") {
+		t.Fatalf("query still has version: %s", targetURL.RawQuery)
+	}
+	if targetURL.Query().Get("tag") != "v1" {
+		t.Fatalf("tag query = %q, want v1", targetURL.Query().Get("tag"))
+	}
+
+	outbound := buildCleanProxyHeaders(ids, rawHeaders, targetURL, node, config.ProxyEnv{}, false)
+
+	// 验证五元组
+	if got := outbound.Get("X-Emby-Client"); got != "Yamby" {
+		t.Fatalf("X-Emby-Client = %q, want Yamby", got)
+	}
+	if got := outbound.Get("X-Emby-Client-Version"); got != "2.0.4.6" {
+		t.Fatalf("X-Emby-Client-Version = %q, want 2.0.4.6", got)
+	}
+	if got := outbound.Get("X-Emby-Device-Name"); got != "Android" {
+		t.Fatalf("X-Emby-Device-Name = %q, want Android", got)
+	}
+	derivedID := identity.DeriveDeviceID(node.Secret, "yamby", "vidhub-device-uuid-1", identity.GetProfile("yamby"))
+	if got := outbound.Get("X-Emby-Device-Id"); got != derivedID {
+		t.Fatalf("X-Emby-Device-Id = %q, want derived %q", got, derivedID)
+	}
+	// UA 必须带闭合括号
+	if got := outbound.Get("User-Agent"); got != "Yamby/2.0.4.6(Android)" {
+		t.Fatalf("User-Agent = %q, want Yamby/2.0.4.6(Android)", got)
+	}
+	// Authorization
+	wantAuth := "Emby Client=Yamby,Device=Android,DeviceId=" + derivedID + ",Version=2.0.4.6"
+	if got := outbound.Get("X-Emby-Authorization"); got != wantAuth {
+		t.Fatalf("X-Emby-Authorization = %q, want %q", got, wantAuth)
+	}
+	// Token 只出站 X-Emby-Token
+	if got := outbound.Get("X-Emby-Token"); got != "vidhub-token-123" {
+		t.Fatalf("X-Emby-Token = %q, want vidhub-token-123", got)
+	}
+	if strings.Contains(outbound.Get("X-Emby-Authorization"), "vidhub-token-123") {
+		t.Fatalf("Authorization must not contain token")
+	}
+}
+
+func TestImpersonatedDeviceIDDerivationAndTokenAlias(t *testing.T) {
+	ids := identity.NewManager(nil)
+	node := storage.Node{
+		Impersonate:        true,
+		ImpersonateProfile: "yamby",
+		Secret:             "secret-1",
+	}
+
+	targetURL, _ := url.Parse("https://upstream.example/emby/Items")
+
+	// 1. 两个不同入站 DeviceId -> 产生不同出站 ID
+	hA := http.Header{"X-Emby-Device-Id": {"dev-A"}, "X-Emby-Token": {"tok-A"}}
+	outA1 := buildCleanProxyHeaders(ids, hA, targetURL, node, config.ProxyEnv{}, false)
+
+	hB := http.Header{"X-Emby-Device-Id": {"dev-B"}, "X-Emby-Token": {"tok-B"}}
+	outB := buildCleanProxyHeaders(ids, hB, targetURL, node, config.ProxyEnv{}, false)
+
+	if outA1.Get("X-Emby-Device-Id") == outB.Get("X-Emby-Device-Id") {
+		t.Fatalf("different inbound device IDs should yield different outbound IDs: %q", outA1.Get("X-Emby-Device-Id"))
+	}
+
+	// 2. 同一入站 DeviceId 多次请求 -> 同一出站 ID
+	outA2 := buildCleanProxyHeaders(ids, hA, targetURL, node, config.ProxyEnv{}, false)
+	if outA1.Get("X-Emby-Device-Id") != outA2.Get("X-Emby-Device-Id") {
+		t.Fatalf("same inbound device ID must yield identical outbound ID")
+	}
+
+	// 3. 先发带 DeviceId+Token 的 API，后续只带 Token 的播放直链 -> 复用出站 ID
+	directURL, _ := url.Parse("https://upstream.example/emby/Videos/123/stream.mp4?api_key=tok-A")
+	directHeaders := http.Header{}
+	applyIdentityToDirectURL(ids, directURL, directHeaders, node)
+
+	if got := directHeaders.Get("X-Emby-Device-Id"); got != outA1.Get("X-Emby-Device-Id") {
+		t.Fatalf("token alias lookup = %q, want same as API request %q", got, outA1.Get("X-Emby-Device-Id"))
+	}
+
+	// 4. 纯 Token 且未命中映射（冷启动直链）-> 回落到 KV 持久 ID，禁止随机
+	fallbackURL, _ := url.Parse("https://upstream.example/emby/Videos/999/stream.mp4?api_key=unknown-tok")
+	fallbackHeaders := http.Header{}
+	applyIdentityToDirectURL(ids, fallbackURL, fallbackHeaders, node)
+
+	snap := ids.Snapshot("yamby")
+	if got := fallbackHeaders.Get("X-Emby-Device-Id"); got != snap.DeviceID {
+		t.Fatalf("fallback device ID = %q, want profile snapshot ID %q", got, snap.DeviceID)
 	}
 }

--- a/internal/proxy/response_test.go
+++ b/internal/proxy/response_test.go
@@ -4349,12 +4349,15 @@ func assertHillsOutboundHeaderIdentityApplied(t *testing.T, ids *identity.Manage
 	if got := req.Header.Get("X-Emby-Authorization"); !strings.Contains(got, `Client="`+snap.ClientName+`"`) {
 		t.Fatalf("X-Emby-Authorization header = %q, want Hills identity", got)
 	}
+	if got := req.Header.Get("X-Emby-Client"); got != snap.ClientName {
+		t.Fatalf("X-Emby-Client header = %q, want %q", got, snap.ClientName)
+	}
 	if got := req.Header.Get("X-Emby-Token"); got != token {
 		t.Fatalf("X-Emby-Token header = %q, want %q", got, token)
 	}
 	assertHeadersAbsent(t, req.Header,
 		"Authorization", "X-Authorization",
-		"X-Emby-Client", "X-MediaBrowser-Client",
+		"X-MediaBrowser-Client",
 	)
 }
 


### PR DESCRIPTION
### 变更内容

1. **开伪装**：
   - 补齐四独立头（`X-Emby-Client`、`X-Emby-Client-Version`、`X-Emby-Device-Name`、`X-Emby-Device-Id`）
   - 始终构造出站 `X-Emby-Authorization`（不依赖入站是否有 Auth，覆盖入站 Auth，无引号、无 UserId/Token）
   - 规范化 Profile UA 补齐闭合右括号（`Yamby/2.0.4.6(Android)`）
   - DeviceId 按入站设备标识基于 HMAC 稳定派生（同设备多次连接保持一致，不同客户端隔离，Token 做别名映射，禁止每连接随机）
   - Query 参数剥离补充删除 `client` 与 `version`，禁止身份残留

2. **关伪装**：
   - 修复无 UA 时 `Del("User-Agent")` 导致 Go 自动补充 `Go-http-client/1.1` 的问题，保留 nil 抑制默认 UA；有 UA 则正常透传
   - 缺少 `X-Emby-Client` 独立头时，自动从已有 Authorization `Client=` 或 query `client` 补缺，不改写已有头

3. **架构边界**：
   - 不做代理侧客户端白名单，不做聚合器

### 测试验证
- `go test` 与 `go vet` 全量通过